### PR TITLE
Changing delay as well as adding date/time in generate-traffic

### DIFF
--- a/bookinfo/demo-4-virtual-service-reviews-jason-v2-v3-delay.yaml
+++ b/bookinfo/demo-4-virtual-service-reviews-jason-v2-v3-delay.yaml
@@ -14,7 +14,7 @@ spec:
       delay:
         percentage:
           value: 100.0
-        fixedDelay: 7s
+        fixedDelay: 3s
     route:
     - destination:
         host: reviews

--- a/bookinfo/generate-traffic.sh
+++ b/bookinfo/generate-traffic.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+export $(./2-gateway-url.sh)
+
 while [ true ]
 do
-    curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL/productpage
+    response=$(curl -o /dev/null -s -w "%{http_code}\n" http://$GATEWAY_URL/productpage)
+    echo "[$(date +'%m/%d/%Y %H:%M:%S')] - $response"
     sleep .1
 done


### PR DESCRIPTION
1. Changing delay from `7s` to `3s` (much nicer during a demo)
1. Updating the `generate-traffic.sh` script to output date/time in addition to the response code